### PR TITLE
don't use n_numeric and n_counts for analysis

### DIFF
--- a/analysis/memory_analysis.R
+++ b/analysis/memory_analysis.R
@@ -29,7 +29,7 @@ mem_data <-
   select(-sparse, -dense) %>%
   summarize(
     log_fold = median(log_fold),
-    .by = c(model, sparsity, n_numeric, n_counts, n_rows)
+    .by = c(model, sparsity, n_rows)
   )
 
 # ------------------------------------------------------------------------------
@@ -152,3 +152,7 @@ augment(mars_fit, mem_te) %>%
 augment(mars_fit, mem_te) %>%
   metrics(log_fold, .pred)
 
+augment(mars_fit, mem_te) |>
+  ggplot(aes(.pred, log_fold)) +
+  geom_point() +
+  facet_wrap(~model)

--- a/analysis/time_analysis.R
+++ b/analysis/time_analysis.R
@@ -29,7 +29,7 @@ time_data <-
   select(-sparse, -dense) %>%
   summarize(
     log_fold = median(log_fold),
-    .by = c(model, sparsity, n_numeric, n_counts, n_rows)
+    .by = c(model, sparsity, n_rows)
   )
 
 # ------------------------------------------------------------------------------
@@ -152,3 +152,7 @@ augment(mars_fit, time_te) %>%
 augment(mars_fit, time_te) %>%
   metrics(log_fold, .pred)
 
+augment(mars_fit, time_te) |>
+  ggplot(aes(.pred, log_fold)) +
+  geom_point() +
+  facet_wrap(~model)


### PR DESCRIPTION
since we don't have access to `n_numeric` or `n_counts` at fitting time, we shouldn't include them for our analysis.

We simulated lots of `n_numeric` and `n_counts` to get a richer data set with many values of `sparsity`